### PR TITLE
xtask: Build all eBPF programs by default

### DIFF
--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -3,13 +3,6 @@ use std::process::Command;
 
 use clap::Parser;
 
-#[derive(Debug, Copy, Clone, clap::ArgEnum)]
-pub enum BuildLibrary {
-    All,
-    Aya,
-    Libbpf,
-}
-
 #[derive(Debug, Copy, Clone)]
 pub enum Architecture {
     BpfEl,
@@ -45,8 +38,6 @@ pub struct Options {
     /// Build the release target
     #[clap(long)]
     pub release: bool,
-    #[clap(arg_enum, long, default_value_t = BuildLibrary::All)]
-    pub ebpf_lib: BuildLibrary,
 }
 
 pub fn build_ebpf_aya(opts: Options) -> Result<(), anyhow::Error> {
@@ -83,12 +74,6 @@ pub fn build_ebpf_libbpf() -> Result<(), anyhow::Error> {
 }
 
 pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
-    match opts.ebpf_lib {
-        BuildLibrary::All => {
-            build_ebpf_aya(opts)?;
-            build_ebpf_libbpf()
-        }
-        BuildLibrary::Aya => build_ebpf_aya(opts),
-        BuildLibrary::Libbpf => build_ebpf_libbpf(),
-    }
+    build_ebpf_aya(opts)?;
+    build_ebpf_libbpf()
 }

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -3,7 +3,7 @@ use std::{os::unix::process::CommandExt, process::Command};
 use anyhow::Context as _;
 use clap::Parser;
 
-use crate::build_ebpf::{build_ebpf, Architecture, BuildLibrary, Options as BuildOptions};
+use crate::build_ebpf::{build_ebpf, Architecture, Options as BuildOptions};
 
 #[derive(Debug, Copy, Clone, clap::ArgEnum)]
 pub enum RunLibrary {
@@ -48,17 +48,9 @@ fn build(opts: &Options) -> Result<(), anyhow::Error> {
 /// Build and run the project
 pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     // build our ebpf program followed by our application
-    let build_opts = match opts.ebpf_lib {
-        RunLibrary::Aya => BuildOptions {
-            target: opts.bpf_target,
-            release: opts.release,
-            ebpf_lib: BuildLibrary::Aya,
-        },
-        RunLibrary::Libbpf => BuildOptions {
-            target: opts.bpf_target,
-            release: opts.release,
-            ebpf_lib: BuildLibrary::Libbpf,
-        },
+    let build_opts = BuildOptions {
+        target: opts.bpf_target,
+        release: opts.release,
     };
     build_ebpf(build_opts).context("Error while building eBPF program")?;
     build(&opts).context("Error while building userspace applications")?;


### PR DESCRIPTION
The default behavior of `cargo xtask run` (as well as `cargo run`) towards the userspace crates is to build them all. To be consistent, let's also build all eBPF programs as well. Without all eBPF programs, build of some userspace crates might fail.

After this change, the `--userspace-lib` and `--ebpf-lib` have impact only on which project to run. It has no impact anymore on what's built - for safety, we build everything.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>