### PR TITLE
Fix the Aya userspace + libbpf eBPF example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ of Aya and libbpf, both in userspace and eBPF:
   Aya eBPF is currently emiting wrong BTF (rejected by libbpf userspacew), so we probably want to
   do similar validation in Aya userspace.**
 * [`userspace-aya-ebpf-libbpf`](https://github.com/vadorovsky/aya-btf-maps/tree/main/userspace-aya-ebpf-libbpf) -
-  Aya used in usespace to load a correct libbpf program. **It's not working, which means we do
-  something wrong in Aya, since libbpf loads it without problems. Support of BTF maps in Aya userspace
-  is most likely broken.**
+  Aya used in usespace to load a correct libbpf program. **It works, but there is a room for improvement,
+  like [handling section / program names](https://github.com/aya-rs/aya/issues/375).**
 
 ## Prerequisites
 

--- a/ebpf/fork-ebpf-libbpf/fork.bpf.c
+++ b/ebpf/fork-ebpf-libbpf/fork.bpf.c
@@ -17,7 +17,7 @@ struct fork_ctx {
 	unsigned int child_pid;
 };
 
-SEC("tp/sched/sched_process_fork")
+SEC("tp/fork")
 int fork(void *ctx) {
 	struct fork_ctx *fork_ctx = (struct fork_ctx *)ctx;
 	unsigned int parent_pid = fork_ctx->parent_pid;

--- a/fork-common/Cargo.toml
+++ b/fork-common/Cargo.toml
@@ -8,7 +8,7 @@ default = []
 user = [ "aya" ]
 
 [dependencies]
-aya = { version = ">=0.11", optional=true }
+aya = { git = "https://github.com/aya-rs/aya", branch = "main", optional=true }
 
 [lib]
 path = "src/lib.rs"

--- a/userspace-aya-ebpf-aya/Cargo.toml
+++ b/userspace-aya-ebpf-aya/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = { version = ">=0.11", features=["async_tokio"] }
+aya = { git = "https://github.com/aya-rs/aya", branch = "main", features=["async_tokio"] }
 fork-common = { path = "../fork-common", features=["user"] }
 anyhow = "1.0.42"
 clap = { version = "3.1", features = ["derive"] }

--- a/userspace-aya-ebpf-libbpf/Cargo.toml
+++ b/userspace-aya-ebpf-libbpf/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = { version = ">=0.11", features=["async_tokio"] }
+aya = { git = "https://github.com/aya-rs/aya", branch = "main", features=["async_tokio"] }
 fork-common = { path = "../fork-common", features=["user"] }
 anyhow = "1.0.42"
 clap = { version = "3.1", features = ["derive"] }

--- a/userspace-aya-ebpf-libbpf/src/main.rs
+++ b/userspace-aya-ebpf-libbpf/src/main.rs
@@ -1,12 +1,11 @@
-use aya::{include_bytes_aligned, Bpf};
 use aya::programs::TracePoint;
+use aya::{include_bytes_aligned, Bpf};
 use clap::Parser;
 use log::{info, warn};
 use tokio::signal;
 
 #[derive(Debug, Parser)]
-struct Opt {
-}
+struct Opt {}
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {


### PR DESCRIPTION
* Switch to `main` branch of Aya
* Switch the section name to `tp/fork`, so the program name is always `fork` and is not being truncated.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>