### PR TITLE
Add libbpf as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ebpf/fork-ebpf-libbpf/libbpf"]
+	path = ebpf/fork-ebpf-libbpf/libbpf
+	url = https://github.com/libbpf/libbpf

--- a/ebpf/fork-ebpf-libbpf/.gitignore
+++ b/ebpf/fork-ebpf-libbpf/.gitignore
@@ -1,1 +1,1 @@
-fork.bpf.o
+dist/

--- a/ebpf/fork-ebpf-libbpf/Makefile
+++ b/ebpf/fork-ebpf-libbpf/Makefile
@@ -1,8 +1,22 @@
 CLANG ?= clang
 LLC ?= llc
 
-.PHONY: all
-all: fork.bpf.o
+OUT_DIR ?= dist
 
-fork.bpf.o: fork.bpf.c
-	$(CLANG) -O2 -target bpf -emit-llvm -c -g $< -o -| $(LLC) -march=bpf -filetype=obj -o $@
+LIBBPF_SRC = libbpf/src
+LIBBPF_DIR = $(OUT_DIR)/libbpf
+LIBBPF_HEADERS := $(LIBBPF_DIR)/usr/include
+
+.PHONY: all
+all: $(OUT_DIR)/fork.bpf.o
+
+$(OUT_DIR):
+	mkdir -p $@
+
+$(LIBBPF_HEADERS) $(LIBBPF_HEADERS)/bpf $(LIBBPF_HEADERS)/linux:
+	$(MAKE) -C $(LIBBPF_SRC) DESTDIR=$(abspath $(LIBBPF_DIR)) \
+		install_headers	install_uapi_headers
+
+$(OUT_DIR)/fork.bpf.o: fork.bpf.c $(LIBBPF_HEADERS)
+	$(CLANG) -I $(LIBBPF_HEADERS) -O2 -target bpf -emit-llvm -c -g $< -o -| \
+		$(LLC) -march=bpf -filetype=obj -o $@


### PR DESCRIPTION
To not require a system-wide installation of libbpf.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>